### PR TITLE
do not render this component with a default div tag

### DIFF
--- a/addon/components/deferred-content.js
+++ b/addon/components/deferred-content.js
@@ -12,6 +12,7 @@ const {
 const DeferredContentComponent = Component.extend({
   layout,
   isPending: not('isSettled'),
+  tagName:'',
   promise: computed({
     set(key, promise) {
       set(this, 'isRejected', false);


### PR DESCRIPTION
The default div tag is not needed, and may destruct the structure of relative html (e.g. wrap table body in if condition )