### PR TITLE
deferred-content sub components will not render empty DOM nodes

### DIFF
--- a/addon/components/deferred-content/fulfilled-content.js
+++ b/addon/components/deferred-content/fulfilled-content.js
@@ -4,5 +4,6 @@ import layout from '../../templates/components/deferred-content/fulfilled-conten
 const { Component } = Ember;
 
 export default Component.extend({
-  layout
+  layout,
+  tagName: ''
 });

--- a/addon/components/deferred-content/pending-content.js
+++ b/addon/components/deferred-content/pending-content.js
@@ -4,5 +4,6 @@ import layout from '../../templates/components/deferred-content/pending-content'
 const { Component } = Ember;
 
 export default Component.extend({
-  layout
+  layout,
+  tagName: ''
 });

--- a/addon/components/deferred-content/rejected-content.js
+++ b/addon/components/deferred-content/rejected-content.js
@@ -4,5 +4,6 @@ import layout from '../../templates/components/deferred-content/rejected-content
 const { Component } = Ember;
 
 export default Component.extend({
-  layout
+  layout,
+  tagName: ''
 });

--- a/addon/components/deferred-content/settled-content.js
+++ b/addon/components/deferred-content/settled-content.js
@@ -4,5 +4,6 @@ import layout from '../../templates/components/deferred-content/settled-content'
 const { Component } = Ember;
 
 export default Component.extend({
-  layout
+  layout,
+  tagName: ''
 });

--- a/tests/integration/deferred-content-test.js
+++ b/tests/integration/deferred-content-test.js
@@ -279,3 +279,30 @@ skip('raises assertion when passed argument that is not promise', function(asser
     );
   }
 });
+
+test('should not render empty wrapper DOM nodes', function (assert) {
+  assert.expect(1);
+
+  let deferred = RSVP.defer();
+
+  this.set('promise', deferred.promise);
+
+  this.render(hbs`{{#deferred-content promise as |d|}}
+    {{#d.settled}}
+    {{/d.settled}}
+    {{#d.pending}}
+    {{/d.pending}}
+    {{#d.fulfilled}}
+    {{/d.fulfilled}}
+    {{#d.rejected}}
+    {{/d.rejected}}
+  {{/deferred-content}}`);
+
+  deferred.resolve();
+
+  return wait()
+    .then(() => {
+      assert.equal(this.$().children().length, 0);
+    });
+});
+


### PR DESCRIPTION
Currently, when using the library like so:

```handlebars
{{#deferred-content promise as |d|}}
    {{#d.settled}}
    {{/d.settled}}
    {{#d.pending}}
    {{/d.pending}}
    {{#d.fulfilled}}
    {{/d.fulfilled}}
    {{#d.rejected}}
    {{/d.rejected}}
{{/deferred-content}}
```
You will see 4 empty `ember-view` nodes in the dom.  This PR prevents that from happening.
Having a bunch of extra wrapper nodes happens to break my layouts. There is a work around by passing `tagName=''` to all the yielded components. But that is noisy. So I selfishly want this pushed upstream.

This could be a backwards incompatible change if people are relying on those nodes being present. So I will leave the semvar up to you. 

Adds test to ensure sub components do not render DOM nodes
Adds tagName:'' to all sub components
closes #4